### PR TITLE
Do a de-dplyr of dehex dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dehex
-Title: Learn to Quickly Assess Hex Code Colours
+Title: Learn to Roughly Assess Hex Code Colours
 Version: 0.0.0.9000
 Authors@R: 
     person(given = "Matt",
@@ -21,5 +21,5 @@ Imports:
     stats,
     crayon,
     purrr,
-    dplyr,
-    graphics
+    graphics,
+    grid

--- a/R/dehex.R
+++ b/R/dehex.R
@@ -215,26 +215,27 @@ dh_solve <- function(hex_code, graphs = TRUE, swatch = TRUE) {
   hue_solved        <- names(Filter(isTRUE, hue_rank_list_lgl))
 
   # User's saturation solved
-  sat_solved <- dplyr::case_when(
-    user_range == 0 ~ "grey",
-    user_range >= 1  & user_range <= 5  ~ "muted",
-    user_range >= 6  & user_range <= 11  ~ "washed",
-    user_range >= 12 & user_range <= 16 ~ "saturated",
-    TRUE ~ "ERROR"
-  )
+  if (user_range == 0) {
+    sat_solved <- "grey"
+  } else if (user_range >= 1  & user_range <= 5) {
+    sat_solved <- "muted"
+  } else if (user_range >= 6  & user_range <= 11 ) {
+    sat_solved <- "washed"
+  } else if (user_range >= 12 & user_range <= 16) {
+    sat_solved <- "saturated"
+  } else {
+    stop("sat_solved result not valid")
+  }
 
   # User's lightness solved
-  light_solved <- dplyr::case_when(
-    user_mean >= 0  & user_mean <= 5  ~ "dark",
-    user_mean >= 6  & user_mean <= 10 ~ "middle",
-    user_mean >= 11 & user_mean <= 16 ~ "light",
-    TRUE ~ "ERROR"
-  )
-
-  if (swatch) {
-
-    dh_swatch(hex_short)
-
+  if (user_mean >= 0  & user_mean <= 5) {
+    light_solved <- "dark"
+  } else if (user_mean >= 6  & user_mean <= 10) {
+    light_solved <- "middle"
+  } else if (user_mean >= 11 & user_mean <= 16) {
+    light_solved <- "light"
+  } else {
+    stop("light_solved result not valid")
   }
 
   if (!graphs) {

--- a/man/dehex-package.Rd
+++ b/man/dehex-package.Rd
@@ -4,7 +4,7 @@
 \name{dehex-package}
 \alias{dehex}
 \alias{dehex-package}
-\title{dehex: Learn to Quickly Assess Hex Code Colours}
+\title{dehex: Learn to Roughly Assess Hex Code Colours}
 \description{
 Follow David DeSanto's method to quickly generate a rough colour
     name by looking only at its hex code.


### PR DESCRIPTION
Remove {dplyr} from dependencies; was only being used for `case_when()`. Closes #15.