### PR TITLE
Fixes link to blog post in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https:
 
 > To remove a hex (a spell, especially an evil spell).
 
-An R package containing simple functions to help me train myself to 'read' a colour from its hex code. I'm colourblind (a deuteranope) so this might be a useful skill. [Read the accompanying blog post](https://github.com/matt-dray/dehex) for more info.
+An R package containing simple functions to help me train myself to 'read' a colour from its hex code. I'm colourblind (a deuteranope) so this might be a useful skill. [Read the accompanying blog post](https://www.rostrum.blog/2021/08/10/dehex/) for more info.
 
 ## The DeSandro method
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ post](https://img.shields.io/badge/rostrum.blog-post-008900?labelColor=000000&lo
 An R package containing simple functions to help me train myself to
 ‘read’ a colour from its hex code. I’m colourblind (a deuteranope) so
 this might be a useful skill. [Read the accompanying blog
-post](https://github.com/matt-dray/dehex) for more info.
+post](https://www.rostrum.blog/2021/08/10/dehex/) for more info.
 
 ## The DeSandro method
 


### PR DESCRIPTION
The link to the blog post in the README had been going to the README itself.

Very neat package! 🎨